### PR TITLE
[WIP] Replication Simulator

### DIFF
--- a/data/shallow-100n-tiny.js
+++ b/data/shallow-100n-tiny.js
@@ -1,0 +1,14 @@
+module.exports = async serialize => {
+  const store = new Map()
+  let i = 0
+  let parts = []
+  while (i < 100) {
+    let block = await serialize({test: Math.random()})
+    store.set(block.cid.multihash.toString('base64'), block.data)
+    parts.push(block.cid)
+    i++
+  }
+  let root = await serialize({parts})
+  store.set(root.cid.multihash.toString('base64'), root.data)
+  return [store, root.cid, ['/', '/parts']]
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+let { runner } = require('./lib/util')
+
+let createData = require('./data/shallow-100n-tiny')
+let createNetwork = require('./networks/1-peer-no-throttle')
+let replicator = require('./replicators/bitswap-serial')
+
+runner(createData, createNetwork, replicator).then(r => console.log(r))

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,34 @@
+const net = require('net')
+const getport = require('get-port')
+const cbor = require('dag-cbor-sync')()
+
+const createClientServer = async () => {
+  let port = await getport()
+  return new Promise((resolve, reject) => {
+    let client
+    let server = net.createServer(socket => {
+      resolve([socket, client])
+    })
+    server.listen(port, err => {
+      if (err) return reject(err)
+      client = net.connect(port)
+    })
+  })
+}
+
+const run = async (createData, createNetwork, replicator, serializer = cbor.mkblock) => {
+  let [store, root, paths, cacheRoot, cacheStore] = await createData(serializer)
+  let network = await createNetwork(store)
+  network.forEach(arr => arr.push(store))
+  let results = {}
+  for (let path of paths) {
+    let start = Date.now()
+    await replicator(root, path, network, cacheRoot, cacheStore)
+    let end = Date.now()
+    results[path] = (end - start)
+  }
+  return results
+}
+
+exports.createClientServer = createClientServer
+exports.runner = run

--- a/networks/1-peer-no-throttle.js
+++ b/networks/1-peer-no-throttle.js
@@ -1,0 +1,6 @@
+const {createClientServer} = require('../lib/util')
+
+module.exports = async store => {
+  let [server, client] = await createClientServer()
+  return [[server, client]]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "ipld-replication",
+  "version": "0.1.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.mikealrogers.com)",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "dag-cbor-links": "^1.1.0",
+    "dag-cbor-sync": "^0.6.0",
+    "get-port": "^4.0.0",
+    "ipld-dag-cbor": "^0.13.0",
+    "stream-throttle": "^0.1.3",
+    "znode": "^1.1.3"
+  },
+  "devDependencies": {
+    "babel-eslint": "^8.2.5",
+    "eslint": "^5.0.1",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-config-standard-babel": "0.0.2",
+    "eslint-plugin-babel": "^5.1.0",
+    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-standard": "^3.1.0",
+    "tap": "^12.0.1"
+  },
+  "eslintConfig": {
+    "parser": "babel-eslint",
+    "extends": [
+      "standard",
+      "standard-babel"
+    ],
+    "plugins": [
+      "babel",
+      "standard"
+    ]
+  },
+  "directories": {
+    "test": "test"
+  }
+}

--- a/replicators/bitswap-serial.js
+++ b/replicators/bitswap-serial.js
@@ -1,0 +1,75 @@
+const znode = require('znode')
+const links = require('dag-cbor-links')
+
+class AquireBlock {
+  constructor (network) {
+    network.forEach(arr => {
+      arr.push(false)
+    })
+
+    for (let net of network) {
+      let [service, client, store] = net
+      let getBlock = hashString => {
+        if (store.has(hashString)) {
+          return store.get(hashString)
+        } else {
+          throw new Error('Not Found')
+        }
+      }
+      znode(service, {getBlock})
+      let promise = znode(client)
+      let _getBlock = async hashString => {
+        let remote = await promise
+        client.busy = true
+        let buff = await remote.getBlock(hashString)
+        client.busy = false
+        this.free(_getBlock)
+        return buff
+      }
+      net.push(_getBlock)
+    }
+    this.network = network
+    this.pending = []
+  }
+  async getBlock (cid) {
+    cid = cid.multihash.toString('base64')
+    for (let [, client, , , _getBlock] of this.network) {
+      if (!client.busy) {
+        return _getBlock(cid)
+      }
+    }
+    return new Promise(resolve => {
+      this.pending([resolve, cid])
+    })
+  }
+  async free (getBlock) {
+    if (this.pending.length) {
+      let [resolve, cid] = this.pending.shift()
+      resolve(getBlock(cid))
+    }
+  }
+}
+
+const replicator = async (root, path, network, cacheRoot, store = new Map()) => {
+  let ab = new AquireBlock(network)
+
+  let sync = async cid => {
+    let data
+    let cidString = cid.multihash.toString('base64')
+    if (!store.has(cidString)) {
+      data = await ab.getBlock(cid)
+      console.log(data.length)
+      store.set(cidString, data)
+    } else {
+      data = store.get(cidString)
+    }
+    let promises = []
+    for (let [, link] of links(data)) {
+      promises.push(sync(link))
+    }
+    return Promise.all(promises)
+  }
+  await sync(root)
+}
+
+module.exports = replicator


### PR DESCRIPTION
This branch is still a work in progress but it's worth discussing the approach.

Essentially, this gives us a way to write the following test conditions:

* data: return an in-memory Map() as a Block store along with a root CID and paths you can replicate.
  * This is flexible enough to let us write any graph in a codec agnostic way. I'm still debating if the codec agnostic part is necessary, there might be some benefit to having each data case be specific to a codec.
  * Currently, the data needs to fit in memory. For most tests this is ideal because it removes disc performance as a factor in measuring but we will eventually want larger graphs that don't fit in memory.
  * You can also optionally return both a cache storage Map() for the replicator to initialize with along with the old rootNode. This should allow us to test all the re-sync and test cases we've considered.
* networks: return an array of streams for the client and server connection and the storage Map() of each peer.
  * This allows us to create peer networks from 1 to many and to simulate constrained network conditions and rountrip delays for both the replicator client and the individual peers using `stream-throttle`.
  * We need to figure out a good way for peers to remove parts of total dataset as a network condition. "peers with incomplete data" is best modeled as a network condition but it's unclear to me how to best express this.
* replicators: functions that contain all the logic for a potential replication scheme.
* TODO: rpc interfaces: agnostic RPC functions different replicators can require.

This setup should allow us to run simulations of each replication scheme for each data set X each network condition.